### PR TITLE
Add `stopOnError` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,5 @@
 declare namespace pAll {
-	interface Options {
-		/**
-		Number of concurrent pending promises. Minimum: `1`.
-
-		@default Infinity
-		*/
-		concurrency?: number;
-	}
+	type Options = import('p-map').Options;
 
 	type PromiseFactory<T> = () => PromiseLike<T>;
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-map": "^2.0.0"
+		"p-map": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Minimum: `1`
 
 Number of concurrent pending promises.
 
+##### stopOnError
+
+Type: `boolean`\
+Default: `true`
+
+When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
+
 
 ## Related
 


### PR DESCRIPTION
my main reason for upgrading p-map is that I wanted to use `stopOnError:false` with `p-all`. I also refactored the `p-all` typings so it directly refers the `Options` types from `p-map` so it will automatically expose all possible options in the typings