### PR TITLE
Upgrade p-map to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-map": "^5.0.0"
+		"p-map": "^6.0.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
Upgrade `p-map` to [v6](https://github.com/sindresorhus/p-map/releases/tag/v6.0.0), removing the `aggregate-error` dependency.